### PR TITLE
Valet update

### DIFF
--- a/app/src/main/java/finance/valet/HubActivity.scala
+++ b/app/src/main/java/finance/valet/HubActivity.scala
@@ -849,19 +849,24 @@ class HubActivity extends NfcReaderActivity with ChanErrorHandlerActivity with E
 
     val usdCard: CardView = view.findViewById(R.id.usdCard).asInstanceOf[CardView]
     val eurCard: CardView = view.findViewById(R.id.eurCard).asInstanceOf[CardView]
+    val satCard: CardView = view.findViewById(R.id.satCard).asInstanceOf[CardView]
 
     val totalLightningBalance: TextView = view.findViewById(R.id.totalLightningBalance).asInstanceOf[TextView]
     val totalUsdBalance: TextView = view.findViewById(R.id.totalUsdBalance).asInstanceOf[TextView]
     val totalEurBalance: TextView = view.findViewById(R.id.totalEurBalance).asInstanceOf[TextView]
+    val totalSatBalance: TextView = view.findViewById(R.id.totalSatBalance).asInstanceOf[TextView]
     val channelStateIndicators: RelativeLayout = view.findViewById(R.id.channelStateIndicators).asInstanceOf[RelativeLayout]
     val channelStateIndicatorsUsd: RelativeLayout = view.findViewById(R.id.channelStateIndicatorsUsd).asInstanceOf[RelativeLayout]
     val channelStateIndicatorsEur: RelativeLayout = view.findViewById(R.id.channelStateIndicatorsEur).asInstanceOf[RelativeLayout]
+    val channelStateIndicatorsSat: RelativeLayout = view.findViewById(R.id.channelStateIndicatorsSat).asInstanceOf[RelativeLayout]
     val channelIndicator: ChannelIndicatorLine = view.findViewById(R.id.channelIndicator).asInstanceOf[ChannelIndicatorLine]
     val channelIndicatorUsd: ChannelIndicatorLine = view.findViewById(R.id.channelIndicatorUsd).asInstanceOf[ChannelIndicatorLine]
     val channelIndicatorEur: ChannelIndicatorLine = view.findViewById(R.id.channelIndicatorEur).asInstanceOf[ChannelIndicatorLine]
+    val channelIndicatorSat: ChannelIndicatorLine = view.findViewById(R.id.channelIndicatorSat).asInstanceOf[ChannelIndicatorLine]
     val lnBalanceFiat: TextView = view.findViewById(R.id.lnBalanceFiat).asInstanceOf[TextView]
     val lnBalanceFiatUsd: TextView = view.findViewById(R.id.lnBalanceFiatUsd).asInstanceOf[TextView]
     val lnBalanceFiatEur: TextView = view.findViewById(R.id.lnBalanceFiatEur).asInstanceOf[TextView]
+    val lnBalanceSat: TextView = view.findViewById(R.id.lnBalanceSat).asInstanceOf[TextView]
 
     val inFlightIncoming: TextView = view.findViewById(R.id.inFlightIncoming).asInstanceOf[TextView]
     val inFlightOutgoing: TextView = view.findViewById(R.id.inFlightOutgoing).asInstanceOf[TextView]
@@ -926,12 +931,14 @@ class HubActivity extends NfcReaderActivity with ChanErrorHandlerActivity with E
       val allChannels = LNParams.cm.allBtc.values.take(8)
       val usdChannels = LNParams.cm.fiatUsd.values.take(8)
       val eurChannels = LNParams.cm.fiatEur.values.take(8)
+      val satChannels = LNParams.cm.standardHostedChannels.values.take(8)
 
       val lnBalance = Channel.totalBalance(LNParams.cm.allBtc.values.map(_._1))
       val lnBalanceUsd = LNParams.cm.fiatUsd.values.map(_._2.fiatValue).sum
       val lnBalanceUsdSats = LNParams.cm.fiatUsd.values.map(_._1.data.ourBalance).sum
       val lnBalanceEur = LNParams.cm.fiatEur.values.map(_._2.fiatValue).sum
       val lnBalanceEurSats = LNParams.cm.fiatEur.values.map(_._1.data.ourBalance).sum
+      val lnBalanceSatSats = LNParams.cm.standardHostedChannels.values.map(_._1.data.ourBalance).sum
 
       val localInCount = LNParams.cm.inProcessors.count { case (fullTag, _) => fullTag.tag == PaymentTagTlv.FINAL_INCOMING }
       val trampolineCount = LNParams.cm.inProcessors.count { case (fullTag, _) => fullTag.tag == PaymentTagTlv.TRAMPLOINE_ROUTED }
@@ -960,11 +967,17 @@ class HubActivity extends NfcReaderActivity with ChanErrorHandlerActivity with E
       lnBalanceFiatEur.setText(WalletApp currentMsatInFiatHuman lnBalanceEurSats)
       channelIndicatorEur.createIndicators(eurChannels.map(_._1).toArray)
 
+      // SAT Hosted channel
+      totalSatBalance.setText(WalletApp.denom.parsedWithSign(lnBalanceSatSats, cardIn, lnCardZero).html)
+      lnBalanceSat.setText(WalletApp currentMsatInFiatHuman lnBalanceSatSats)
+      channelIndicatorSat.createIndicators(satChannels.map(_._1).toArray)
+
       setVisMany(allChannels.nonEmpty -> channelStateIndicators,
         allChannels.nonEmpty -> totalLightningBalance,
         allChannels.isEmpty -> addChannelTip,
         usdChannels.nonEmpty -> usdCard,
-        eurChannels.nonEmpty -> eurCard)
+        eurChannels.nonEmpty -> eurCard,
+        satChannels.nonEmpty -> satCard)
 
       // We have updated chain wallet balances at this point because listener in WalletApp gets called first
       chainCards.update(LNParams.chainWallets.wallets)

--- a/app/src/main/java/immortan/ChannelMaster.scala
+++ b/app/src/main/java/immortan/ChannelMaster.scala
@@ -211,6 +211,16 @@ class ChannelMaster(val payBag: PaymentBag, val chanBag: ChannelBag, val dataBag
 
   def hostedByTicker(ticker: Ticker): Map[ByteVector32, (Channel, HostedCommits)] = allHosted.filter { case (_, (_, commits)) => commits.lastCrossSignedState.initHostedChannel.ticker == ticker }
 
+  // Standard Hosted Channels (SAT ticker) - satoshi denominated, no fiat conversion
+  def standardHostedChannels: Map[ByteVector32, (Channel, HostedCommits)] = hostedByTicker(Ticker.SAT_TICKER)
+
+  // Fiat Channels - USD, EUR, or other fiat-denominated channels
+  def fiatChannels: Map[ByteVector32, (Channel, HostedCommits)] = allHosted.filter { case (_, (_, commits)) => Ticker.isFiat(commits.lastCrossSignedState.initHostedChannel.ticker) }
+
+  // All hosted channel commits (both standard HC and Fiat channels)
+  def allStandardHostedCommits: Iterable[HostedCommits] = standardHostedChannels.values.map(_._2)
+  def allFiatCommits: Iterable[HostedCommits] = fiatChannels.values.map(_._2)
+
   def allFromNode(nodeId: PublicKey): Iterable[ChanAndCommits] = all.values.flatMap(Channel.chanAndCommitsOpt).filter(_.commits.remoteInfo.nodeId == nodeId)
 
   def hostedFromNode(nodeId: PublicKey): Option[ChannelHosted] = allFromNode(nodeId).collectFirst { case ChanAndCommits(chan: ChannelHosted, _) => chan }

--- a/app/src/main/java/immortan/Ticker.scala
+++ b/app/src/main/java/immortan/Ticker.scala
@@ -14,14 +14,33 @@ case class EUR() extends Ticker {
   def tag = "EUR"
 }
 
+/// Standard Hosted Channel ticker - satoshi denominated, no fiat conversion
+case class SAT() extends Ticker {
+  def tag = "SAT"
+}
+
 object Ticker {
   final val USD_TICKER = USD()
   final val EUR_TICKER = EUR()
+  final val SAT_TICKER = SAT()
 
   final val knownTickers: Set[Ticker] = Set(
     USD_TICKER,
-    EUR_TICKER
+    EUR_TICKER,
+    SAT_TICKER
   )
+
+  /// Check if ticker is a fiat ticker (requires rate conversion)
+  def isFiat(ticker: Ticker): Boolean = ticker match {
+    case SAT() => false
+    case _ => true
+  }
+
+  /// Check if ticker is standard hosted channel (no rate conversion)
+  def isHostedChannel(ticker: Ticker): Boolean = ticker match {
+    case SAT() => true
+    case _ => false
+  }
 
   def tickerByTag(tag: String): Option[Ticker] = {
     knownTickers.find(_.tag == tag)

--- a/app/src/main/res/layout/frag_wallet_cards.xml
+++ b/app/src/main/res/layout/frag_wallet_cards.xml
@@ -346,6 +346,71 @@
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 
+        <!-- Hosted Channel (SAT) card -->
+        <androidx.cardview.widget.CardView
+            card_view:cardCornerRadius="@dimen/corner_radius"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:layout_marginTop="5dp"
+            android:onClick="goToStatPage"
+            android:id="@+id/satCard"
+            style="@style/Card">
+
+            <LinearLayout
+                android:padding="15dp"
+                android:orientation="vertical"
+                android:background="@color/cardHostedSat"
+                style="@style/FillingView">
+
+                <!-- Text and balance -->
+
+                <RelativeLayout style="@style/FillingView">
+
+                    <TextView
+                        android:layout_marginEnd="3dp"
+                        android:textColor="@color/colorAccent"
+                        android:text="@string/hosted_wallet_sat"
+                        android:layout_centerVertical="true"
+                        style="@style/BoundedView"/>
+
+                    <TextView
+                        android:id="@+id/totalSatBalance"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true"
+                        style="@style/Emphasized"/>
+
+                </RelativeLayout>
+
+                <!-- Indicators and payment state -->
+
+                <RelativeLayout
+                    style="@style/FillingView"
+                    android:id="@+id/channelStateIndicatorsSat">
+
+                    <com.indicator.ChannelIndicatorLine
+                        android:id="@+id/channelIndicatorSat"
+                        android:layout_centerVertical="true"
+                        style="@style/BoundedView"/>
+
+                    <LinearLayout
+                        android:layout_marginTop="6dp"
+                        android:layout_centerVertical="true"
+                        android:layout_alignParentEnd="true"
+                        android:orientation="horizontal"
+                        style="@style/BoundedView">
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_marginTop="6dp"
+                        android:layout_centerVertical="true"
+                        android:layout_alignParentEnd="true"
+                        android:id="@+id/lnBalanceSat"
+                        style="@style/BoundedView"/>
+
+                </RelativeLayout>
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
         <!-- Recovery phrase warning -->
 
         <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,8 +18,9 @@
     <color name="cardLightning">#4F5B8F</color>
     <color name="cardBitcoinModern">#876319</color>
     <color name="cardBitcoinLegacy">#5A5A5A</color>
-    <color name="cardFiatUsd">#66937f</color>>
+    <color name="cardFiatUsd">#66937f</color>
     <color name="cardFiatEur">#806993</color>
+    <color name="cardHostedSat">#7A6B4F</color>
 
     <color name="buttonGreenRipple">#8BD670</color>
     <color name="buttonGreenBorder">#5B8F36</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,7 @@
     <string name="fiat_wallet">Fiat</string>
     <string name="fiat_wallet_usd">USD</string>
     <string name="fiat_wallet_eur">EUR</string>
+    <string name="hosted_wallet_sat">Hosted</string>
     <!-- /CPFP/RBF -->
 
 </resources>


### PR DESCRIPTION
This PR introduces two major features:
- Standard Hosted Channels (SAT) - Brought back the Sats-denominated hosted channels client side implementation.
- Nostr Wallet Connect (NWC) - To connect external apps like Stacker News to the wallet for zapping purposes.

Other minor updates:

- Cleaned up the UI display when a user Scans a Node QR
- Optimized the camera pop up for QR scan (Initially had a serious lag that required double clicking on the "Scan Node QR" button before camera pops up)
- Updated the SATM node credentials for automatic Fiat channels opening without scanning the SATM  Node QR code

All changes completely tested and functional.

@evd0kim