### PR TITLE
fix(fdroid): Use --alignment-preserved true and apksigcopier check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # apksigcopier is the tool fdroidserver uses to transplant our signature onto its own
+      # rebuild. It reconstructs the v1 signature entries with Python's zipfile, and Python 3.13
+      # changed zipfile to drop the UTF-8 general-purpose flag that apksigner sets on those
+      # entries -- under 3.13 the check fails on APKs that are perfectly fine. Pin 3.12, which is
+      # what F-Droid's buildserver runs. See REPRODUCIBLE_BUILDS.md.
+      - name: Set up apksigcopier
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install apksigcopier==1.1.1
+
       # A silently-empty keystore surfaces as an unreadable ASN.1 error inside apksigner
       # ("Tag number over 30 is not supported"), so validate here where the message can
       # say what actually went wrong.
@@ -75,6 +86,26 @@ jobs:
           export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH ($(date -u -d "@$SOURCE_DATE_EPOCH"))"
           ./gradlew assembleRelease -Porg.gradle.java.installations.fromEnv=JAVA_HOME_11_X64
+
+      # gradle's verify<Variant>Apk already asserts that signing did not touch the entry region.
+      # This runs the real thing on top: exactly the apksigcopier + apksigner round trip
+      # fdroidserver performs when it compares its rebuild to the APK published here. If this
+      # passes, F-Droid's verification of this release passes too.
+      - name: Verify the signature transplants onto an unsigned rebuild
+        shell: bash
+        run: |
+          set -euo pipefail
+          apksigner="$ANDROID_HOME/build-tools/36.0.0/apksigner"
+          test -x "$apksigner" || { echo "::error::build-tools 36.0.0 apksigner not found"; exit 1; }
+          for signed in $(find app/build/outputs/apk -path '*/release/*.apk'); do
+            unsigned="$signed.unsigned"
+            test -f "$unsigned" || { echo "::error::missing $unsigned"; exit 1; }
+            echo "== $(basename "$signed")"
+            apksigcopier copy "$signed" "$unsigned" /tmp/transplanted.apk
+            "$apksigner" verify --verbose /tmp/transplanted.apk > /dev/null
+            echo "   signature verifies against the unsigned build"
+            rm -f /tmp/transplanted.apk
+          done
 
       # Every flavour's release APK, under the name build.gradle already gives it
       # (<applicationId>_<versionCode>.apk), so nothing here has to track versionCode

--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ podman run -v $PWD:/app/valet:z valet
 
 The container runs `./gradlew assembleRelease && ./gradlew bundleRelease`, producing
 an APK for every product flavor (`mainnet`, `tnet3`, `tnet4`, `regtest`) under
-`app/build/outputs/apk/release/`, named `<applicationId>_<versionCode>.apk`
-(e.g. `finance.valet_107.apk` for mainnet), plus `.aab` bundles under
+`app/build/outputs/apk/<flavor>/release/`, named `<applicationId>_<versionCode>.apk`
+(e.g. `finance.valet_111.apk` for mainnet), plus `.aab` bundles under
 `app/build/outputs/bundle/release/`.
+
+Released APKs have to be reproducible byte for byte, because F-Droid rebuilds them and
+refuses to publish a release it cannot reproduce. Read
+[REPRODUCIBLE_BUILDS.md](REPRODUCIBLE_BUILDS.md) before changing anything about how the
+APK is packaged or signed.
 
 ### Signing APKs with your self-signed certificate
 
@@ -60,31 +65,31 @@ variables are present at build time, so for APKs you usually don't need to run
 
    With these variables set, every `assemble<Flavor>Release` task is finalized by a
    `sign<Flavor>ReleaseApk` task that zipaligns and signs the APK in place
-   (`--v1-signing-enabled true --v2-signing-enabled true`). If `SIGNING_KEY_ALIAS`
-   is not set, the build still normalizes timestamps and zipaligns the APK, but
-   leaves it unsigned.
+   (`--v1-signing-enabled true --v2-signing-enabled true`), followed by a
+   `verify<Flavor>ReleaseApk` task that checks the result is still reproducible.
+   If `SIGNING_KEY_ALIAS` is not set, the build still normalizes timestamps and
+   zipaligns the APK, but leaves it unsigned.
 
 #### Manually signing an unsigned APK
 
-If you ended up with an unsigned (but already zipaligned) APK, sign it directly with
-`apksigner`:
+Don't, if the APK is going to be published. F-Droid rebuilds each release and grafts the
+published signature onto its own build; that only works if signing left the ZIP layout
+untouched, and `apksigner` rewrites the alignment padding of every uncompressed entry
+unless it is told not to. The build's signing task passes the flag that prevents this and
+then proves it worked — a hand-rolled `apksigner sign` does neither.
+
+If you are signing a throwaway build for a device, the invocation the build uses is:
 
 ```
-$ <Android SDK dir>/build-tools/<version>/apksigner sign \
+$ <Android SDK dir>/build-tools/36.0.0/apksigner sign \
+    --alignment-preserved true \
     --ks release.keystore --ks-key-alias release \
     --v1-signing-enabled true --v2-signing-enabled true \
-    app/build/outputs/apk/release/finance.valet_107.apk
+    app/build/outputs/apk/mainnet/release/finance.valet_111.apk
 ```
 
-If the APK isn't aligned yet, align it first:
-
-```
-$ <Android SDK dir>/build-tools/<version>/zipalign -v 4 \
-    app/build/outputs/apk/release/finance.valet_107.apk \
-    app/build/outputs/apk/release/finance.valet_107-aligned.apk
-```
-
-then sign the `-aligned.apk` file and rename it back if desired.
+The APK must already be zipaligned, which `assemble<Flavor>Release` does. Do not run
+`zipalign` on it again afterwards. See [REPRODUCIBLE_BUILDS.md](REPRODUCIBLE_BUILDS.md).
 
 ### Signing App Bundles (`.aab`)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,7 @@
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
@@ -175,12 +179,60 @@ tasks.withType(Jar).configureEach {
     from { files.sort() }
 }
 
+// Offset of the central directory, i.e. the size of the entry region of a ZIP.
+// No ZIP64 here: an APK that large would not install anyway.
+static long centralDirectoryOffset(File zip) {
+    def raf = new RandomAccessFile(zip, 'r')
+    try {
+        int tailLen = (int) Math.min(zip.length(), 22L + 0xffff)
+        byte[] tail = new byte[tailLen]
+        raf.seek(zip.length() - tailLen)
+        raf.readFully(tail)
+        for (int i = tailLen - 22; i >= 0; i--) {
+            if (tail[i] == 0x50 && tail[i + 1] == 0x4b && tail[i + 2] == 0x05 && tail[i + 3] == 0x06) {
+                return ByteBuffer.wrap(tail, i + 16, 4).order(ByteOrder.LITTLE_ENDIAN).getInt() & 0xffffffffL
+            }
+        }
+    } finally {
+        raf.close()
+    }
+    throw new GradleException("not a ZIP file: ${zip}")
+}
+
+/** Offset of the first byte in which a and b differ over `length` bytes, or -1 if none. */
+static long firstDifference(File a, File b, long length) {
+    byte[] bufA = new byte[1 << 16]
+    byte[] bufB = new byte[1 << 16]
+    def inA = new DataInputStream(new BufferedInputStream(new FileInputStream(a)))
+    def inB = new DataInputStream(new BufferedInputStream(new FileInputStream(b)))
+    try {
+        for (long pos = 0; pos < length;) {
+            int n = (int) Math.min((long) bufA.length, length - pos)
+            inA.readFully(bufA, 0, n)
+            inB.readFully(bufB, 0, n)
+            for (int i = 0; i < n; i++) {
+                if (bufA[i] != bufB[i]) return pos + i
+            }
+            pos += n
+        }
+        return -1L
+    } finally {
+        inA.close()
+        inB.close()
+    }
+}
+
 android.applicationVariants.all { variant ->
     if (variant.buildType.name != 'release') return
 
     def variantName = variant.name.capitalize()
     def buildToolsDir = "${android.sdkDirectory}/build-tools/${android.buildToolsVersion}"
     def apkProvider = { variant.outputs.first().outputFile }
+    // apksigner signs in place, so the pre-signing bytes -- which are exactly what
+    // F-Droid's builder ends up with, since it has no key and never runs signTask --
+    // are kept aside for verifyTask. The suffix deliberately does not end in `.apk`
+    // so that release tooling globbing for '*.apk' does not pick it up.
+    def unsignedApkProvider = { file("${apkProvider().absolutePath}.unsigned") }
 
     def normalizeTask = tasks.create("normalize${variantName}ApkTimestamps") {
         doLast {
@@ -230,11 +282,30 @@ android.applicationVariants.all { variant ->
         }
     }
 
-    def signTask = tasks.create("sign${variantName}Apk", Exec) {
+    // Alignment is what makes the layout of the unsigned APK final: apksigner is told to
+    // preserve it and apksigcopier never introduces it, so if zipalign were ever to not take
+    // effect the APK would ship unaligned -- which Android 11+ refuses to install, and which
+    // no later step would notice. `-c` re-checks the file zipalign just wrote.
+    def alignCheckTask = tasks.create("check${variantName}ApkAlignment", Exec) {
         dependsOn zipalignTask
+        doFirst {
+            commandLine "${buildToolsDir}/zipalign", '-c', '-p', '4', apkProvider().absolutePath
+        }
+    }
+
+    def signTask = tasks.create("sign${variantName}Apk", Exec) {
+        dependsOn alignCheckTask
         onlyIf { System.getenv("SIGNING_KEY_ALIAS") != null }
         doFirst {
+            Files.copy(apkProvider().toPath(), unsignedApkProvider().toPath(),
+                    StandardCopyOption.REPLACE_EXISTING)
             commandLine "${buildToolsDir}/apksigner", 'sign',
+                    // Mandatory. Without it apksigner re-pads every uncompressed entry with its
+                    // own 0xd935 alignment records, rewriting the ZIP layout that zipalign just
+                    // produced. F-Droid transplants this APK's signature onto its own rebuild
+                    // with apksigcopier, which copies entries verbatim and never re-pads, so any
+                    // layout change here makes the v2/v3 digests mismatch on their builder.
+                    // See REPRODUCIBLE_BUILDS.md.
                     '--alignment-preserved', 'true',
                     '--ks', System.getenv("SIGNING_STORE_FILENAME") ?: '',
                     '--ks-key-alias', System.getenv("SIGNING_KEY_ALIAS") ?: '',
@@ -248,8 +319,36 @@ android.applicationVariants.all { variant ->
         }
     }
 
-    def pgpSignTask = tasks.create("pgpSign${variantName}Apk", Exec) {
+    // F-Droid rebuilds the APK from source, transplants the published signature onto its own
+    // build with apksigcopier and checks the v2/v3 digests. That only succeeds if signing left
+    // every byte before the signature untouched, so assert exactly that: signing may append the
+    // v1 signature entries and insert the APK Signing Block, and nothing else. Catching a
+    // violation here costs one comparison; catching it in F-Droid's CI costs a re-release.
+    def verifyTask = tasks.create("verify${variantName}Apk") {
         dependsOn signTask
+        onlyIf { System.getenv("SIGNING_KEY_ALIAS") != null }
+        doLast {
+            def signed = apkProvider()
+            def unsigned = unsignedApkProvider()
+            long contentSize = centralDirectoryOffset(unsigned)
+
+            if (signed.length() <= contentSize) {
+                throw new GradleException("${signed.name}: signing shrank the APK -- expected the "
+                        + "unsigned entry region (${contentSize} bytes) plus a signature")
+            }
+            long diff = firstDifference(unsigned, signed, contentSize)
+            if (diff >= 0) {
+                throw new GradleException("${signed.name} is not reproducible: signing rewrote the "
+                        + "ZIP layout, first differing byte at offset ${diff} of ${contentSize}. "
+                        + "F-Droid will not be able to verify this build. See REPRODUCIBLE_BUILDS.md.")
+            }
+            logger.lifecycle("${signed.name}: signature added over an unmodified "
+                    + "${contentSize}-byte entry region -- reproducible for F-Droid")
+        }
+    }
+
+    def pgpSignTask = tasks.create("pgpSign${variantName}Apk", Exec) {
+        dependsOn verifyTask
         onlyIf { System.getenv("SIGNING_KEY_ALIAS") != null &&
                 System.getenv("PGP_SIGNING_KEY_ID") != null }
         doFirst {
@@ -265,5 +364,9 @@ android.applicationVariants.all { variant ->
         }
     }
 
-    variant.assembleProvider.configure { finalizedBy(signTask, pgpSignTask) }
+    // alignCheckTask is listed explicitly so that it also runs on builders that have no signing
+    // key -- F-Droid's, in particular -- where signTask and everything after it is skipped.
+    variant.assembleProvider.configure {
+        finalizedBy(alignCheckTask, signTask, verifyTask, pgpSignTask)
+    }
 }

--- a/sign-apk.sh
+++ b/sign-apk.sh
@@ -1,9 +1,54 @@
-#! /usr/bin/env nix-shell
-#!nix-shell -i bash -p androidsdk_9_0 -p apksigner
-set -xe
-echo $PATH
-zipalign=~/Android/Sdk/build-tools/30.0.3/zipalign
-VERSION=4.4.4
-rm app/build/outputs/apk/release/Valet-$VERSION-aligned.apk || true
-$zipalign -v 4 app/build/outputs/apk/release/Valet-$VERSION.apk app/build/outputs/apk/release/Valet-$VERSION-aligned.apk
-apksigner sign --ks release.keystore --ks-key-alias release --v1-signing-enabled true --v2-signing-enabled true app/build/outputs/apk/release/Valet-$VERSION-aligned.apk
+#!/usr/bin/env bash
+#
+# Build and sign the release APKs.
+#
+# Signing is part of the gradle build (sign<Variant>Apk), so this script only supplies
+# the environment those tasks read. Do not sign an APK by hand: apksigner rewrites the
+# alignment padding of every uncompressed entry unless it is passed
+# --alignment-preserved true, and that rewrite is invisible in the installed app but
+# makes F-Droid's verification of the release fail. See REPRODUCIBLE_BUILDS.md.
+#
+# Usage:  SIGNING_STORE_PASSWORD=... ./sign-apk.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${SIGNING_STORE_FILENAME:=$PWD/release.keystore}"
+: "${SIGNING_KEY_ALIAS:=release}"
+
+if [ ! -f "$SIGNING_STORE_FILENAME" ]; then
+    echo "keystore not found: $SIGNING_STORE_FILENAME" >&2
+    echo "set SIGNING_STORE_FILENAME to point at it" >&2
+    exit 1
+fi
+
+if [ -z "${SIGNING_STORE_PASSWORD:-}" ]; then
+    read -r -s -p "keystore password: " SIGNING_STORE_PASSWORD
+    echo
+fi
+
+export SIGNING_STORE_FILENAME SIGNING_KEY_ALIAS SIGNING_STORE_PASSWORD
+export SIGNING_KEY_PASSWORD="${SIGNING_KEY_PASSWORD:-$SIGNING_STORE_PASSWORD}"
+
+# fdroidserver derives SOURCE_DATE_EPOCH from the checked-out commit's timestamp, and the
+# entry timestamps it produces have to match ours, so derive it exactly the same way.
+# TZ matters too: ZipEntry.setTime() converts the epoch using the default time zone.
+export SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
+export TZ=UTC
+echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH ($(date -u -d "@$SOURCE_DATE_EPOCH"))"
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "warning: working tree is dirty -- F-Droid builds the commit, not your tree" >&2
+fi
+
+./gradlew assembleRelease
+
+# verify<Variant>Apk already ran as part of the build and asserted that signing changed
+# nothing but the signature. Print both digests: the unsigned one is what F-Droid's
+# builder produces, so it is the digest to compare against when a rebuild is disputed.
+echo
+while IFS= read -r apk; do
+    echo "$apk"
+    echo "  signed   $(sha256sum "$apk" | cut -d' ' -f1)"
+    echo "  unsigned $(sha256sum "$apk.unsigned" | cut -d' ' -f1)"
+done < <(find app/build/outputs/apk -path '*/release/*.apk' | sort)

--- a/tools/compare-apk-layout.py
+++ b/tools/compare-apk-layout.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Explain why a published APK and a rebuild of it are not the same file.
+
+F-Droid does not compare the two APKs directly: it takes the signature off the
+published one, transplants it onto its own unsigned rebuild with apksigcopier and
+checks that the v2/v3 digests still match.  Those digests cover the whole ZIP,
+so the rebuild has to agree with the published APK byte for byte over everything
+that precedes the signature -- not just in the files it contains, but in ZIP
+metadata nobody normally looks at: entry order, compression, local header fields
+and the alignment padding in the extra field.
+
+`fdroid build --test` only reports "digest mismatch" plus a `diff -r` of the
+unpacked trees, which is empty whenever the difference is in that metadata.  This
+prints the difference instead.
+
+    tools/compare-apk-layout.py published.apk rebuild.apk
+
+The rebuild is expected to be unsigned (the v1 signature entries and the APK
+Signing Block of the published APK are ignored).  Exit status is 0 when the
+rebuild can carry the published signature.
+"""
+
+import struct
+import sys
+import zipfile
+
+META = ('META-INF/MANIFEST.MF',)
+META_SUFFIXES = ('.SF', '.RSA', '.DSA', '.EC')
+
+
+def is_signature_entry(name):
+    """v1 (JAR) signature files, which apksigner appends and apksigcopier re-creates."""
+    if name in META:
+        return True
+    return name.startswith('META-INF/') and name.endswith(META_SUFFIXES) \
+        and '/' not in name[len('META-INF/'):]
+
+
+def local_headers(path):
+    """Per-entry local file header fields, in physical order."""
+    raw = open(path, 'rb').read()
+    out = []
+    with zipfile.ZipFile(path) as zf:
+        for info in sorted(zf.infolist(), key=lambda i: i.header_offset):
+            off = info.header_offset
+            if raw[off:off + 4] != b'PK\x03\x04':
+                sys.exit(f'{path}: no local file header at {off}')
+            (_, ver, flags, method, mtime, mdate, crc, csize, usize,
+             nlen, elen) = struct.unpack('<IHHHHHIIIHH', raw[off:off + 30])
+            out.append(dict(
+                name=info.filename, offset=off, version=ver, flags=flags,
+                method=method, dostime=(mdate << 16) | mtime, crc=crc,
+                lfh_csize=csize, lfh_usize=usize,
+                extra=raw[off + 30 + nlen:off + 30 + nlen + elen],
+                data_offset=off + 30 + nlen + elen,
+                csize=info.compress_size, usize=info.file_size,
+                cd_crc=info.CRC, date_time=info.date_time,
+            ))
+    return out, raw
+
+
+def central_directory_offset(raw):
+    eocd = raw.rfind(b'PK\x05\x06')
+    return struct.unpack('<I', raw[eocd + 16:eocd + 20])[0]
+
+
+def describe_extra(extra):
+    if not extra:
+        return 'none'
+    if extra[:2] == b'\x35\xd9':
+        return f'apksigner alignment record (0xd935), {len(extra)} bytes'
+    if not any(extra):
+        return f'{len(extra)} zero bytes (zipalign padding)'
+    return f'{len(extra)} bytes: {extra.hex()}'
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__.strip().splitlines()[0] + '\n\nusage: '
+                 f'{sys.argv[0]} published.apk rebuild.apk')
+    published, rebuild = sys.argv[1], sys.argv[2]
+
+    pub, pub_raw = local_headers(published)
+    reb, reb_raw = local_headers(rebuild)
+    pub = [e for e in pub if not is_signature_entry(e['name'])]
+    reb = [e for e in reb if not is_signature_entry(e['name'])]
+    problems = []
+
+    pub_names = [e['name'] for e in pub]
+    reb_names = [e['name'] for e in reb]
+    if set(pub_names) != set(reb_names):
+        only_pub = [n for n in pub_names if n not in set(reb_names)]
+        only_reb = [n for n in reb_names if n not in set(pub_names)]
+        problems.append(f'entry sets differ: only in published {only_pub[:10]}, '
+                        f'only in rebuild {only_reb[:10]}')
+    elif pub_names != reb_names:
+        i = next(k for k in range(len(pub_names)) if pub_names[k] != reb_names[k])
+        problems.append(f'entry order differs from index {i}: published has '
+                        f'{pub_names[i]!r}, rebuild has {reb_names[i]!r}')
+    else:
+        # Same entries in the same order: report the first field that differs, per class,
+        # so one run tells you whether it is content, compression or ZIP bookkeeping.
+        fields = [
+            ('cd_crc', 'file contents (CRC)'),
+            ('method', 'compression method'),
+            ('csize', 'compressed size (compressor or its settings differ)'),
+            ('date_time', 'entry timestamp (SOURCE_DATE_EPOCH or TZ differs)'),
+            ('flags', 'general purpose flags'),
+            ('version', 'version-needed-to-extract'),
+            ('lfh_crc', 'local header CRC/size fields'),
+        ]
+        for key, what in fields:
+            if key == 'lfh_crc':
+                bad = [(a, b) for a, b in zip(pub, reb)
+                       if (a['crc'], a['lfh_csize'], a['lfh_usize'])
+                       != (b['crc'], b['lfh_csize'], b['lfh_usize'])]
+                if bad:
+                    a, b = bad[0]
+                    problems.append(
+                        f'{what}: {len(bad)} entries, e.g. {a["name"]!r} '
+                        f'published crc={a["crc"]:#x} sizes={a["lfh_csize"]}/{a["lfh_usize"]}, '
+                        f'rebuild crc={b["crc"]:#x} sizes={b["lfh_csize"]}/{b["lfh_usize"]} '
+                        '-- one side ran the file through a tool that rewrites local '
+                        'headers (zipalign) and the other did not')
+                continue
+            bad = [(a, b) for a, b in zip(pub, reb) if a[key] != b[key]]
+            if bad:
+                a, b = bad[0]
+                problems.append(f'{what}: {len(bad)} entries, e.g. {a["name"]!r} '
+                                f'published {a[key]!r} vs rebuild {b[key]!r}')
+
+        bad = [(a, b) for a, b in zip(pub, reb) if a['extra'] != b['extra']]
+        if bad:
+            a, b = bad[0]
+            problems.append(
+                f'alignment padding: {len(bad)} entries, e.g. {a["name"]!r} '
+                f'published {describe_extra(a["extra"])}, rebuild {describe_extra(b["extra"])} '
+                '-- apksigner realigns unless it is passed --alignment-preserved true, '
+                'and apksigcopier will not undo that')
+
+        same_data = [(a, b) for a, b in zip(pub, reb)
+                     if pub_raw[a['data_offset']:a['data_offset'] + a['csize']]
+                     != reb_raw[b['data_offset']:b['data_offset'] + b['csize']]]
+        if same_data:
+            problems.append(f'compressed bytes: {len(same_data)} entries differ although the '
+                            'entry metadata matches, e.g. ' + repr(same_data[0][0]['name']))
+
+    # The check that actually decides it: everything up to the signature must be identical.
+    content = central_directory_offset(reb_raw)
+    prefix_ok = len(pub_raw) > content and pub_raw[:content] == reb_raw[:content]
+
+    if not problems and prefix_ok:
+        print(f'OK: {published} is {rebuild} plus a signature '
+              f'({content} identical bytes of entry region)')
+        return 0
+
+    print(f'{published} cannot carry a signature verifiable against {rebuild}:')
+    for p in problems:
+        print(f'  - {p}')
+    if not problems and not prefix_ok:
+        first = next(i for i in range(content) if pub_raw[i] != reb_raw[i])
+        print(f'  - entry regions differ from byte {first} although every entry matches; '
+              'the difference is in the central directory or end-of-central-directory record')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Adds harness to ensure that FDroid job will match with the local produced APK. The old way ruins the align of metadata fields.